### PR TITLE
Add Docker compatibility to move off heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:16.18 as build-stage 
+
+COPY . .
+
+ARG BOT_TOKEN
+ENV BOT_TOKEN=${BOT_TOKEN}
+
+ARG BOT_ID
+ENV BOT_ID=${BOT_ID}
+
+ARG DBL_TOKEN
+ENV DBL_TOKEN=${DBL_TOKEN}
+
+ENTRYPOINT [ "node", "startup.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:16.18 as build-stage
 
 COPY . .
 
+RUN yarn install
+
 ARG BOT_TOKEN
 ENV BOT_TOKEN=${BOT_TOKEN}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   ready-bot:
-    container_name: ready-bot
+    container_name: ready-bot-${BOT_ENV}
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+services:
+  ready-bot:
+    container_name: ready-bot
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - "BOT_TOKEN=${BOT_TOKEN}"
+        - "BOT_ID=${BOT_ID}"
+        - "DBL_TOKEN=${DBL_TOKEN}"


### PR DESCRIPTION
Heroku has removed the free dynos that I use to run this bot so I'm docker-ize-ing the whole thing so I can run it elsewhere when I need to.

Adds `Dockerfile` and `docker-compose.yml`